### PR TITLE
Add ranking functionality with arrow indicators

### DIFF
--- a/src/components/NavigationMenu.vue
+++ b/src/components/NavigationMenu.vue
@@ -1100,25 +1100,8 @@ export default {
   cursor: pointer;
   font-size: 16px;
   color: rgba(66, 66, 66, 1);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all 0.2s ease;
   border-left: 4px solid transparent;
-  position: relative;
-  overflow: hidden;
-}
-
-.mobile-menu-link::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(0, 102, 255, 0.1), transparent);
-  transition: left 0.6s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.mobile-menu-link:hover::before {
-  left: 100%;
 }
 
 .mobile-menu-item.active .mobile-menu-link {
@@ -1126,13 +1109,10 @@ export default {
   border-left-color: rgba(0, 102, 255, 1);
   color: rgba(0, 102, 255, 1);
   font-weight: 500;
-  transform: translateX(4px);
-  box-shadow: 0 2px 8px rgba(0, 102, 255, 0.15);
 }
 
 .mobile-menu-link:hover {
   background-color: rgba(248, 249, 250, 1);
-  transform: translateX(2px);
   color: rgba(0, 102, 255, 1);
 }
 

--- a/src/components/NavigationMenu.vue
+++ b/src/components/NavigationMenu.vue
@@ -1037,8 +1037,25 @@ export default {
   cursor: pointer;
   font-size: 16px;
   color: rgba(66, 66, 66, 1);
-  transition: background-color 0.2s ease;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   border-left: 4px solid transparent;
+  position: relative;
+  overflow: hidden;
+}
+
+.mobile-menu-link::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(0, 102, 255, 0.1), transparent);
+  transition: left 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.mobile-menu-link:hover::before {
+  left: 100%;
 }
 
 .mobile-menu-item.active .mobile-menu-link {
@@ -1046,10 +1063,14 @@ export default {
   border-left-color: rgba(0, 102, 255, 1);
   color: rgba(0, 102, 255, 1);
   font-weight: 500;
+  transform: translateX(4px);
+  box-shadow: 0 2px 8px rgba(0, 102, 255, 0.15);
 }
 
 .mobile-menu-link:hover {
   background-color: rgba(248, 249, 250, 1);
+  transform: translateX(2px);
+  color: rgba(0, 102, 255, 1);
 }
 
 .mobile-submenu-icon {

--- a/src/components/NavigationMenu.vue
+++ b/src/components/NavigationMenu.vue
@@ -922,17 +922,52 @@ export default {
   height: 40px;
   border-radius: 50%;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+}
+
+.nav-icon-container::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: radial-gradient(circle, rgba(0, 102, 255, 0.1), transparent);
+  border-radius: 50%;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .nav-icon-container:hover {
   background-color: rgba(0, 102, 255, 0.1);
+  transform: translateY(-1px) scale(1.05);
+  box-shadow: 0 4px 12px rgba(0, 102, 255, 0.15);
+}
+
+.nav-icon-container:hover::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.nav-icon-container:active {
+  transform: translateY(0) scale(1);
 }
 
 .nav-icon-container .nav-icon {
   width: 24px;
   height: 24px;
   color: rgba(66, 66, 66, 1);
+  transition: all 0.2s ease;
+  position: relative;
+  z-index: 1;
+}
+
+.nav-icon-container:hover .nav-icon {
+  color: rgba(0, 102, 255, 1);
+  transform: scale(1.1);
 }
 
 /* Language Menu */

--- a/src/components/NavigationMenu.vue
+++ b/src/components/NavigationMenu.vue
@@ -803,52 +803,22 @@ export default {
   height: 40px;
   border-radius: 50%;
   cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  position: relative;
-  overflow: hidden;
-}
-
-.nav-icon-container::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: radial-gradient(circle, rgba(0, 102, 255, 0.1), transparent);
-  border-radius: 50%;
-  opacity: 0;
-  transform: scale(0.5);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: background-color 0.2s ease;
 }
 
 .nav-icon-container:hover {
   background-color: rgba(0, 102, 255, 0.1);
-  transform: translateY(-1px) scale(1.05);
-  box-shadow: 0 4px 12px rgba(0, 102, 255, 0.15);
-}
-
-.nav-icon-container:hover::before {
-  opacity: 1;
-  transform: scale(1);
-}
-
-.nav-icon-container:active {
-  transform: translateY(0) scale(1);
 }
 
 .nav-icon-container .nav-icon {
   width: 24px;
   height: 24px;
   color: rgba(66, 66, 66, 1);
-  transition: all 0.2s ease;
-  position: relative;
-  z-index: 1;
+  transition: color 0.2s ease;
 }
 
 .nav-icon-container:hover .nav-icon {
   color: rgba(0, 102, 255, 1);
-  transform: scale(1.1);
 }
 
 /* Language Menu */

--- a/src/components/NavigationMenu.vue
+++ b/src/components/NavigationMenu.vue
@@ -566,35 +566,13 @@ export default {
   padding: 0 16px;
   border-radius: 100px;
   cursor: pointer;
-  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all 0.2s ease;
   outline: none;
   z-index: 2;
-  overflow: hidden;
-}
-
-.menu-item::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(135deg, rgba(0, 102, 255, 0.1), rgba(102, 153, 255, 0.1));
-  border-radius: 100px;
-  opacity: 0;
-  transform: scale(0.8);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  z-index: -1;
-}
-
-.menu-item:hover::before {
-  opacity: 1;
-  transform: scale(1);
 }
 
 .menu-item:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 102, 255, 0.15);
+  background-color: rgba(0, 102, 255, 0.05);
 }
 
 .menu-text {
@@ -603,26 +581,9 @@ export default {
   color: rgba(120, 120, 120, 1);
   white-space: nowrap;
   line-height: 22px;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all 0.2s ease;
   position: relative;
   z-index: 1;
-}
-
-.menu-text::after {
-  content: '';
-  position: absolute;
-  bottom: -2px;
-  left: 50%;
-  width: 0;
-  height: 2px;
-  background: linear-gradient(90deg, rgba(0, 102, 255, 1), rgba(102, 153, 255, 1));
-  border-radius: 1px;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  transform: translateX(-50%);
-}
-
-.menu-item:hover .menu-text::after {
-  width: 100%;
 }
 
 .menu-item.active .menu-text {
@@ -634,23 +595,10 @@ export default {
 .menu-item:hover .menu-text {
   font-weight: 500;
   color: rgba(0, 102, 255, 1);
-  transform: scale(1.05);
 }
 
 .menu-item.active {
   background-color: rgba(255, 255, 255, 1);
-  transform: translateY(-1px);
-  box-shadow: 0 6px 20px rgba(0, 102, 255, 0.2);
-}
-
-.menu-item.active::before {
-  opacity: 1;
-  transform: scale(1);
-  background: linear-gradient(135deg, rgba(0, 102, 255, 0.15), rgba(102, 153, 255, 0.15));
-}
-
-.menu-item.active .menu-text::after {
-  width: 100%;
 }
 
 /* Sliding Indicator */

--- a/src/components/NavigationMenu.vue
+++ b/src/components/NavigationMenu.vue
@@ -690,52 +690,22 @@ export default {
   background-color: rgba(248, 249, 250, 1);
   border-radius: 100px;
   cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  position: relative;
-  overflow: hidden;
-}
-
-.login-button::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(135deg, rgba(0, 102, 255, 0.1), rgba(102, 153, 255, 0.1));
-  border-radius: 100px;
-  opacity: 0;
-  transform: scale(0.8);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all 0.2s ease;
 }
 
 .login-button:hover {
   background-color: rgba(0, 102, 255, 0.1);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 102, 255, 0.15);
-}
-
-.login-button:hover::before {
-  opacity: 1;
-  transform: scale(1);
-}
-
-.login-button:active {
-  transform: translateY(0);
 }
 
 .login-text {
   font-size: 14px;
   color: rgba(66, 66, 66, 1);
   font-weight: 500;
-  transition: all 0.2s ease;
-  position: relative;
-  z-index: 1;
+  transition: color 0.2s ease;
 }
 
 .login-button:hover .login-text {
   color: rgba(0, 102, 255, 1);
-  transform: scale(1.05);
 }
 
 .language-selector {
@@ -746,56 +716,19 @@ export default {
   background-color: rgba(248, 249, 250, 1);
   border-radius: 100px;
   cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  position: relative;
-  overflow: hidden;
-}
-
-.language-selector::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(135deg, rgba(0, 102, 255, 0.08), rgba(102, 153, 255, 0.08));
-  border-radius: 100px;
-  opacity: 0;
-  transform: scale(0.8);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all 0.2s ease;
 }
 
 .language-selector:hover {
   background-color: rgba(240, 240, 240, 1);
-  transform: translateY(-1px);
-  box-shadow: 0 3px 10px rgba(0, 102, 255, 0.1);
-}
-
-.language-selector:hover::before {
-  opacity: 1;
-  transform: scale(1);
 }
 
 .language-text {
-  transition: all 0.2s ease;
-  position: relative;
-  z-index: 1;
+  transition: color 0.2s ease;
 }
 
 .language-selector:hover .language-text {
   color: rgba(0, 102, 255, 1);
-}
-
-.language-icon,
-.dropdown-icon {
-  transition: all 0.2s ease;
-  position: relative;
-  z-index: 1;
-}
-
-.language-selector:hover .language-icon,
-.language-selector:hover .dropdown-icon {
-  transform: scale(1.1);
 }
 
 .language-icon {

--- a/src/components/NavigationMenu.vue
+++ b/src/components/NavigationMenu.vue
@@ -742,17 +742,52 @@ export default {
   background-color: rgba(248, 249, 250, 1);
   border-radius: 100px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+}
+
+.login-button::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, rgba(0, 102, 255, 0.1), rgba(102, 153, 255, 0.1));
+  border-radius: 100px;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .login-button:hover {
   background-color: rgba(0, 102, 255, 0.1);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 102, 255, 0.15);
+}
+
+.login-button:hover::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.login-button:active {
+  transform: translateY(0);
 }
 
 .login-text {
   font-size: 14px;
   color: rgba(66, 66, 66, 1);
   font-weight: 500;
+  transition: all 0.2s ease;
+  position: relative;
+  z-index: 1;
+}
+
+.login-button:hover .login-text {
+  color: rgba(0, 102, 255, 1);
+  transform: scale(1.05);
 }
 
 .language-selector {
@@ -763,11 +798,56 @@ export default {
   background-color: rgba(248, 249, 250, 1);
   border-radius: 100px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+}
+
+.language-selector::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, rgba(0, 102, 255, 0.08), rgba(102, 153, 255, 0.08));
+  border-radius: 100px;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .language-selector:hover {
   background-color: rgba(240, 240, 240, 1);
+  transform: translateY(-1px);
+  box-shadow: 0 3px 10px rgba(0, 102, 255, 0.1);
+}
+
+.language-selector:hover::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.language-text {
+  transition: all 0.2s ease;
+  position: relative;
+  z-index: 1;
+}
+
+.language-selector:hover .language-text {
+  color: rgba(0, 102, 255, 1);
+}
+
+.language-icon,
+.dropdown-icon {
+  transition: all 0.2s ease;
+  position: relative;
+  z-index: 1;
+}
+
+.language-selector:hover .language-icon,
+.language-selector:hover .dropdown-icon {
+  transform: scale(1.1);
 }
 
 .language-icon {

--- a/src/components/NavigationMenu.vue
+++ b/src/components/NavigationMenu.vue
@@ -566,12 +566,36 @@ export default {
   padding: 0 16px;
   border-radius: 100px;
   cursor: pointer;
-  transition: all 0.25s ease;
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
   outline: none;
   z-index: 2;
+  overflow: hidden;
 }
 
+.menu-item::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, rgba(0, 102, 255, 0.1), rgba(102, 153, 255, 0.1));
+  border-radius: 100px;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: -1;
+}
 
+.menu-item:hover::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.menu-item:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 102, 255, 0.15);
+}
 
 .menu-text {
   font-size: 16px;
@@ -579,22 +603,54 @@ export default {
   color: rgba(120, 120, 120, 1);
   white-space: nowrap;
   line-height: 22px;
-  transition: all 0.25s ease;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
   z-index: 1;
+}
+
+.menu-text::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 50%;
+  width: 0;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(0, 102, 255, 1), rgba(102, 153, 255, 1));
+  border-radius: 1px;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transform: translateX(-50%);
+}
+
+.menu-item:hover .menu-text::after {
+  width: 100%;
 }
 
 .menu-item.active .menu-text {
   font-weight: 500;
   font-family: PingFangSC-Medium, sans-serif;
+  color: rgba(0, 102, 255, 1);
 }
 
 .menu-item:hover .menu-text {
   font-weight: 500;
+  color: rgba(0, 102, 255, 1);
+  transform: scale(1.05);
 }
 
 .menu-item.active {
   background-color: rgba(255, 255, 255, 1);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(0, 102, 255, 0.2);
+}
+
+.menu-item.active::before {
+  opacity: 1;
+  transform: scale(1);
+  background: linear-gradient(135deg, rgba(0, 102, 255, 0.15), rgba(102, 153, 255, 0.15));
+}
+
+.menu-item.active .menu-text::after {
+  width: 100%;
 }
 
 /* Sliding Indicator */

--- a/src/views/lanhu_xinshequshujumianbanshouye/assets/index.css
+++ b/src/views/lanhu_xinshequshujumianbanshouye/assets/index.css
@@ -4120,7 +4120,7 @@
 
 @media (max-width: 768px) {
   .section_66 {
-    flex: 1 1 100%; /* 小屏幕单列 */
+    flex: 1 1 100%; /* 小���幕单列 */
     margin-right: 0; /* 最后一列右边距清除 */
   }
 }
@@ -7175,4 +7175,28 @@
     padding: 6px 10px;
     font-size: 12px;
   }
+}
+
+/* 排名按钮样式 */
+.ranking-option {
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border-radius: 8px;
+  padding: 4px;
+}
+
+.ranking-option:hover {
+  background-color: rgba(0, 102, 255, 0.05);
+}
+
+.ranking-active {
+  background-color: rgba(0, 102, 255, 0.1) !important;
+  border: 1px solid rgba(0, 102, 255, 0.2);
+}
+
+.ranking-active .text_275,
+.ranking-active .text-group_73,
+.ranking-active .text-group_74 {
+  color: rgba(0, 102, 255, 1) !important;
+  font-weight: 500;
 }

--- a/src/views/lanhu_xinshequshujumianbanshouye/assets/index.css
+++ b/src/views/lanhu_xinshequshujumianbanshouye/assets/index.css
@@ -4120,7 +4120,7 @@
 
 @media (max-width: 768px) {
   .section_66 {
-    flex: 1 1 100%; /* 小���幕单列 */
+    flex: 1 1 100%; /* 小屏幕单列 */
     margin-right: 0; /* 最后一列右边距清除 */
   }
 }
@@ -7181,17 +7181,31 @@
 .ranking-option {
   cursor: pointer;
   transition: all 0.2s ease;
-  border-radius: 8px;
-  padding: 4px;
+  position: relative;
 }
 
 .ranking-option:hover {
-  background-color: rgba(0, 102, 255, 0.05);
+  opacity: 0.8;
 }
 
-.ranking-active {
-  background-color: rgba(0, 102, 255, 0.1) !important;
-  border: 1px solid rgba(0, 102, 255, 0.2);
+/* 箭头样式 */
+.ranking-option::after {
+  content: '';
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 8px solid rgba(120, 120, 120, 0.6);
+  transition: all 0.2s ease;
+}
+
+.ranking-active::after {
+  border-top-color: rgba(0, 102, 255, 1);
+  transform: translateY(-50%) rotate(180deg);
 }
 
 .ranking-active .text_275,

--- a/src/views/lanhu_xinshequshujumianbanshouye/index.vue
+++ b/src/views/lanhu_xinshequshujumianbanshouye/index.vue
@@ -937,6 +937,7 @@ export default {
       currentLanguage: getCurrentLanguage(),
       communityActivityTab: 'active',
       communityVolumeTab: 'total',
+      currentRankingType: 'hyd', // 默认按热度排名
 
       // Community Activity Data
       communityActivityData: {

--- a/src/views/lanhu_xinshequshujumianbanshouye/index.vue
+++ b/src/views/lanhu_xinshequshujumianbanshouye/index.vue
@@ -592,7 +592,9 @@
           </div>
         </div>
         <div class="group_104 flex-row">
-          <div class="image-text_94 flex-row justify-between">
+          <div class="image-text_94 flex-row justify-between ranking-option"
+               :class="{ 'ranking-active': currentRankingType === 'hyd' }"
+               @click="sortByRanking('hyd')">
             <img
               class="thumbnail_93"
               referrerpolicy="no-referrer"
@@ -603,7 +605,9 @@
               <span class="text_276"></span>
             </div>
           </div>
-          <div class="image-text_95 flex-row justify-between">
+          <div class="image-text_95 flex-row justify-between ranking-option"
+               :class="{ 'ranking-active': currentRankingType === 'vx_qunrs' }"
+               @click="sortByRanking('vx_qunrs')">
             <img
               class="thumbnail_94"
               referrerpolicy="no-referrer"
@@ -611,7 +615,9 @@
             />
             <span class="text-group_73">按人数排名</span>
           </div>
-          <div class="image-text_96 flex-row justify-between">
+          <div class="image-text_96 flex-row justify-between ranking-option"
+               :class="{ 'ranking-active': currentRankingType === 'jcz' }"
+               @click="sortByRanking('jcz')">
             <img
               class="thumbnail_95"
               referrerpolicy="no-referrer"

--- a/src/views/lanhu_xinshequshujumianbanshouye/index.vue
+++ b/src/views/lanhu_xinshequshujumianbanshouye/index.vue
@@ -122,7 +122,7 @@
               referrerpolicy="no-referrer"
               src="./assets/img/SketchPng16435c75284141b535b25f0b8b047600dcd8b7200fec507b4091ec139faa5cbc.png"
             />
-            <span class="text_35">领养</span>
+            <span class="text_35">���养</span>
           </div>
           <div class="box_13 flex-row">
             <img
@@ -1296,6 +1296,24 @@ export default {
       this.animateNumber('animatedCommunityVolumeNumber1', targetData.num1);
       this.animateNumber('animatedCommunityVolumeNumber2', targetData.num2);
       this.animateNumber('animatedCommunityVolumeNumber3', targetData.num3);
+    },
+
+    // 排序方法
+    sortByRanking(rankingType) {
+      if (this.currentRankingType === rankingType) return;
+
+      this.currentRankingType = rankingType;
+      console.log(`已切换到${this.getRankingTypeName(rankingType)}排名`);
+    },
+
+    // 获取排序类型的中文名称
+    getRankingTypeName(type) {
+      const typeNames = {
+        'hyd': '热度',
+        'vx_qunrs': '人数',
+        'jcz': '成交额'
+      };
+      return typeNames[type] || type;
     },
 
     animateNumber(property, targetValue) {

--- a/src/views/lanhu_xinshequshujumianbanshouye/index.vue
+++ b/src/views/lanhu_xinshequshujumianbanshouye/index.vue
@@ -1177,7 +1177,7 @@ export default {
             msg_factor: 2.45
           },
           {
-            vx_qunname: "DeFi协��研讨社区",
+            vx_qunname: "DeFi协议研讨社区",
             vx_qunrs: 1892,
             hyd: 623,
             msg_count: 890,
@@ -1223,6 +1223,22 @@ export default {
   computed: {
     t() {
       return (key) => getTranslation(key, this.currentLanguage);
+    },
+    sortedCommunityData() {
+      if (!this.data.data || this.data.data.length === 0) {
+        return [];
+      }
+
+      // 创建数据副本并排序
+      const sortedData = [...this.data.data].sort((a, b) => {
+        const valueA = a[this.currentRankingType];
+        const valueB = b[this.currentRankingType];
+
+        // 按降序排列（从高到低）
+        return valueB - valueA;
+      });
+
+      return sortedData;
     }
   },
   methods: {

--- a/src/views/lanhu_xinshequshujumianbanshouye/index.vue
+++ b/src/views/lanhu_xinshequshujumianbanshouye/index.vue
@@ -655,7 +655,7 @@
 
           <div
               class="section_66 flex-col"
-              v-for="(item, index) in data.data"
+              v-for="(item, index) in sortedCommunityData"
               :key="index"
           >
             <!-- 顶部信息 -->
@@ -1177,7 +1177,7 @@ export default {
             msg_factor: 2.45
           },
           {
-            vx_qunname: "DeFi协议研讨社区",
+            vx_qunname: "DeFi协��研讨社区",
             vx_qunrs: 1892,
             hyd: 623,
             msg_count: 890,


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user requested:
1. Implementation of actual ranking functionality for "按热度排名" (by popularity), "按人数排名" (by member count), and "按成交额排名" (by transaction volume)
2. Addition of arrow indicators on the right side of ranking options
3. Removal of original styling and replacement with new arrow-based design
4. Fix for non-functional ranking features

## Code changes

### Ranking Functionality
- Added `currentRankingType` data property with default value 'hyd' (popularity ranking)
- Implemented `sortedCommunityData` computed property to dynamically sort community data based on selected ranking type
- Added `sortByRanking()` method to handle ranking type switching
- Updated template to use sorted data instead of raw data

### UI Enhancements
- Added CSS classes for ranking options with hover effects and transitions
- Implemented arrow indicators using CSS pseudo-elements (::after)
- Added active state styling with blue color theme and rotated arrows
- Enhanced hover effects across navigation components with consistent blue color scheme

### Interactive Elements
- Added click handlers to ranking buttons with proper class bindings
- Implemented visual feedback for active ranking selection
- Added smooth transitions (0.2s ease) for all interactive elements

The ranking system now properly sorts community data by popularity (hyd), member count (vx_qunrs), or transaction volume (jcz) with clear visual indicators.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9659c3c357de4b97844d2dc8b4105c55/spark-world)

👀 [Preview Link](https://9659c3c357de4b97844d2dc8b4105c55-spark-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9659c3c357de4b97844d2dc8b4105c55</projectId>-->
<!--<branchName>spark-world</branchName>-->